### PR TITLE
Add Dockerfile for React app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+*.log
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Build stage
+FROM node:18-slim AS build
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Build the app
+RUN npm run build
+
+# Production stage
+FROM node:18-slim
+WORKDIR /app
+
+# Copy node modules and built files
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package*.json ./
+
+# Expose the port used by `vite preview`
+EXPOSE 4173
+
+# Run the preview server
+CMD ["npx", "vite", "preview", "--port", "4173", "--host"]


### PR DESCRIPTION
## Summary
- add Dockerfile using Node 18 slim
- ignore build artifacts in `.dockerignore`

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688a4195d80c832e9c9f86ed526c6b81